### PR TITLE
Accessible legend

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,4 @@
-define(["require", "exports", "esri/WebMap", "esri/core/urlUtils", "esri/views/MapView", "esri/core/watchUtils", "esri/core/promiseUtils", "esri/Graphic", "esri/geometry/Extent", "esri/symbols/SimpleFillSymbol", "esri/widgets/Search", "esri/widgets/Home", "esri/tasks/Locator"], function (require, exports, WebMap, urlUtils, MapView, watchUtils, promiseUtils, Graphic, Extent, SimpleFillSymbol, Search, Home, Locator) {
+define(["require", "exports", "esri/WebMap", "esri/core/urlUtils", "esri/views/MapView", "esri/core/watchUtils", "esri/core/promiseUtils", "esri/Graphic", "esri/geometry/Extent", "esri/symbols/SimpleFillSymbol", "esri/widgets/Search", "esri/widgets/Home", "esri/tasks/Locator", "esri/widgets/Legend"], function (require, exports, WebMap, urlUtils, MapView, watchUtils, promiseUtils, Graphic, Extent, SimpleFillSymbol, Search, Home, Locator, Legend) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var watchHandler;
@@ -30,9 +30,9 @@ define(["require", "exports", "esri/WebMap", "esri/core/urlUtils", "esri/views/M
         map: map,
         container: "viewDiv"
     });
-    // Add the live node to the view 
+    // Add the live node to the view
     view.ui.add(liveNode, "manual");
-    // When user tabs into the app for the first time 
+    // When user tabs into the app for the first time
     // add button to navigate map via keyboard to the ui and focus it 
     document.addEventListener("keydown", function handler(e) {
         if (e.keyCode === 9) {
@@ -103,13 +103,27 @@ define(["require", "exports", "esri/WebMap", "esri/core/urlUtils", "esri/views/M
                     }
                 });
             }
-            // add layer as locator to search widget 
+            // add layer as locator to search widget
             searchWidget.sources.push({
                 featureLayer: l,
                 placeholder: "Search " + l.title + " layer",
                 withinViewEnabled: true
             });
         });
+        // Add a legend when the map view loads
+          var featureLayer = map.layers.getItemAt(0); // Grab the first layer from the webmap
+          var legend = new Legend({
+            container: "legendDiv",
+            view: view,
+            layerInfos: [{
+              layer: featureLayer,
+              title: "Trailheads"
+            }]
+          });
+          view.ui.add({
+              component: legend,
+              position: "top-right"
+          });
     });
     function setupKeyHandlers() {
         if (!watchHandler) {
@@ -180,7 +194,7 @@ define(["require", "exports", "esri/WebMap", "esri/core/urlUtils", "esri/views/M
                     liveDirNode.innerHTML = "Moving " + dir + ".";
                 }
                 else if (key === "h") {
-                    /// Go to the view's initial extent 
+                    /// Go to the view's initial extent
                     view.goTo(initialExtent);
                 }
             });
@@ -335,7 +349,7 @@ define(["require", "exports", "esri/WebMap", "esri/core/urlUtils", "esri/views/M
         var begin = ((currentPage - 1) * numberPerPage);
         var end = begin + numberPerPage;
         pageResults = queryResults.slice(begin, end);
-        // Get page status  
+        // Get page status
         var prevDisabled = currentPage === 1; // don't show 8
         var nextDisabled = currentPage === numberOfPages; // don't show 9
         liveNode.setAttribute("aria-busy", "true");
@@ -373,7 +387,7 @@ define(["require", "exports", "esri/WebMap", "esri/core/urlUtils", "esri/views/M
     function addFocusToMap() {
         document.getElementById("intro").innerHTML = "Use the arrow keys to navigate the map and find features. Use the plus (+) key to zoom in to the map and the minus (-) key to zoom out.\n        For details on your current area press the i key. Press the h key to return to the  starting map location.";
         window.addEventListener("mousedown", function (keyEvt) {
-            // Don't show the feature list unless tab is pressed. 
+            // Don't show the feature list unless tab is pressed.
             // prevent default for text box so search works
             if (keyEvt.key !== "Tab") {
                 if (keyEvt.target.type !== "text") {

--- a/index.html
+++ b/index.html
@@ -27,6 +27,12 @@
 
 <body>
     <div id="viewDiv" role="application">
+      <!-- Map title -->
+      <h1 class="offscreen">a11y Map</h1>
+      <!-- Legend -->
+      <div id="legendDiv" tabindex="0">
+        <h2 class="offscreen">Map legend layers:</h2>
+      </div>
     </div>
     <div aria-describedby="intro" id="liveViewInfo" class="hidden live-info" role="navigation">
         <div aria-live="polite" role="status">


### PR DESCRIPTION
Added an accessible dynamic legend to the top right corner of the map. 

<img width="1271" alt="Screenshot of the legend added to the a11y map in the top right corner of the interface" src="https://user-images.githubusercontent.com/5023024/47259314-67098100-d46d-11e8-9da5-161469522bd7.png">

The legend has a `h2` heading indicating "**Map legend layers:**". The heading is not displayed to a sighted user by using the `offscreen` class. The "**:**" character in the heading aims to add a break in speech when a screen reader reads the map layer present in the legend.

Using the title a `h3` heading is added to indicate the name of the map layer (Trailheads):  
<img width="295" alt="Screenshot showing a close up of the legend with the Trailheads layer displayed" src="https://user-images.githubusercontent.com/5023024/47259334-b3ed5780-d46d-11e8-89aa-72435f2ffc25.png">  

To ensure the page heading structure is met a `h1` heading was added to the map, also hidden to sighted users using the `offscreen` class. 

The final heading structure is as follows:  
* `h1`: a11y Map  
* `h2`: Map legend layers:  
* `h3`: Trailheads  
<img width="191" alt="Screenshot of heading levels in the a11y map PR" src="https://user-images.githubusercontent.com/5023024/47259444-54904700-d46f-11e8-97eb-a842a2332cf1.png">  

Updates tested on iOS with: [VoiceOver](https://www.apple.com/accessibility/mac/vision), [aXe](https://www.deque.com/axe), [WAVE](https://wave.webaim.org), and [ChromeVox](http://www.chromevox.com).

cc #11 

P.S. Apologies, typescript was not used in this PR. 